### PR TITLE
Add run configuration to VCS

### DIFF
--- a/.run/Freenet-Site.run.xml
+++ b/.run/Freenet-Site.run.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Freenet-Site" type="Application" factoryName="Application">
+    <envs>
+      <env name="FREENET_SITE_LOCAL_TESTING" value="true" />
+    </envs>
+    <option name="MAIN_CLASS_NAME" value="org.freenet.website.MainKt" />
+    <module name="freenetorg-website.main" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>


### PR DESCRIPTION
This PR setups an IntelliJ run configuration as described in the README, and checks it into git.

A popular place to store this file is .idea/runConfigurations(would need to be whitelisted in gitignore). I just placed the file where IntelliJ defaulted to putting it.